### PR TITLE
Changing Docker env to a Docker-Compose based runtime-configurated environment

### DIFF
--- a/.env.sample.sh
+++ b/.env.sample.sh
@@ -12,6 +12,7 @@ USERNAME=oai-spgwu
 IMAGE_TAG=upee
 IMAGE_VERSION=v1.0
 DOCKERFILE=Dockerfile
+DOCKERCOMPOSEFILE=docker-compose.yml
 SSH_FOLDER=~/.ssh
 SSH_PUBLIC_KEY_FILE=id_rsa.pub
 SSH_PRIVATE_KEY_FILE=id_rsa

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ After dowloaded and installed it, clone this repository:
 git clone https://github.com/navarrothiago/upf-bpf.git
 ```
 
+After cloning the repository, configure your [env.sh](env.sh) file (on the repository root folder) to match your dev or test environment, using the [.env.sample.sh](.env.sample.sh) file as a template
+
 The project use a docker container to build the UPF library. The command below will provision the docker image with all the project dependencies.
 
 > :memo: You'll need the Docker Container Runtime package and the Docker Compose utility to set up the dev or test environment
@@ -134,7 +136,7 @@ package
 
 ## How to test the software
 
-The instructions here is still missing. If you need to know how to test, contact me. There is a lot of script that make the deployment and configuration easier. As you can see in [[.env.sample.sh](.env.sample.sh), there are variables to configure the jump server, trex version, GTP and UDP interfaces (downlink and uplink), etc. Besides, there are UTs for Session Management layers. You can execute with (inside the container).
+The instructions here is still missing. If you need to know how to test, contact me. There is a lot of script that make the deployment and configuration easier. As you can see in [.env.sample.sh](.env.sample.sh), there are variables to configure the jump server, trex version, GTP and UDP interfaces (downlink and uplink), etc. Besides, there are UTs for Session Management layers. You can execute with (inside the container).
 
 ```
 make config-veth-pair

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ git clone https://github.com/navarrothiago/upf-bpf.git
 ```
 
 The project use a docker container to build the UPF library. The command below will provision the docker image with all the project dependencies.
+
 > :memo: You'll need the Docker Container Runtime package and the Docker Compose utility to set up the dev or test environment
 
 ```

--- a/README.md
+++ b/README.md
@@ -92,12 +92,11 @@ git clone https://github.com/navarrothiago/upf-bpf.git
 ```
 
 The project use a docker container to build the UPF library. The command below will provision the docker image with all the project dependencies.
+> :memo: You'll need the Docker Container Runtime package and the Docker Compose utility to set up the dev or test environment
 
 ```
 make docker-build
 ```
-
-> Warning: THE SSH PRIVATE KEY IS COPIED TO THE DOCKER IMAGE. DO NOT PUSH THIS IMAGE TO THE INTERNET!!
 
 After that, run the container with:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,6 @@
 ARG BASE_DEV_IMAGE=ubuntu:20.04
 FROM $BASE_DEV_IMAGE
 
-#Configurations for the test environment
-# ARG JUMP_SERVER_IP
-# ARG JUMP_SERVER_PORT
-# ARG JUMP_SERVER_USERNAME
-# ARG DUT_SERVER_IP
-# ARG TREX_SERVER_IP
-
 #Configurations for the general environment
 ARG UNAME=oai-spgwu
 ARG DEBIAN_FRONTEND=noninteractive
@@ -27,7 +20,7 @@ RUN apt-get update && \
       apt-get -y install sudo tzdata git cmake gcc g++ libconfig++ iproute2 iptables iputils-ping wget \
       python3-pip locales ethtool docker-ce-cli libssl-dev rsync gdb bash-completion tmux \
       tcpdump libelf-dev zlib1g clang llvm libasan5 linux-tools-common linux-headers-generic \
-      g++-multilib libc6-dev-i386 
+      g++-multilib libc6-dev-i386 gosu
 
 #Downloading Docker Compose
 RUN   LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")') \
@@ -42,37 +35,15 @@ RUN if [ $BASE_DEV_IMAGE != "ubuntu:20.04" ];  then \
       wget -c  https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.2.tar.gz -O - | tar -xz && \
       cd cmake-3.19.2 && ./bootstrap && make -j4 && make install; fi
 
-# Add your local bashrc
-ADD .bashrc /home/$USERNAME/
-ADD .bashrc /root/
-
-# Copy over private key, and set permissions
-# WARNING! Anyone who gets their hands on this image will be able
-# to retrieve this private key file from the corresponding image layer
-ADD id_rsa /root/.ssh/id_rsa
-ADD id_rsa.pub /root/.ssh/id_rsa.pub
-ADD config /root/.ssh/config
-ADD id_rsa /home/$USERNAME/.ssh/id_rsa
-ADD id_rsa.pub /home/$USERNAME/.ssh/id_rsa.pub
-ADD config /home/$USERNAME/.ssh/config
-
-# Create known_hosts
-# TODO navarrothiago - Put ssh-keyscan of the dut and trex server.
-RUN touch /root/.ssh/known_hosts
-
 # Locales for Yocto
 RUN echo "$LANG UTF-8" > /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=$LAN
 
-RUN chown root /root/.ssh/config
-
 # TODO: pass as ARG
 RUN echo "ENV_FILE=/workspaces/env.sh" >> /etc/environment
 
-# Omit if you want to keep the default as root.
-# USER $USERNAME
-
+# Copy Entrypoint Script to Container
 COPY entrypoint.sh /entrypoint.sh
 
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,90 +1,50 @@
 ARG BASE_DEV_IMAGE=ubuntu:20.04
 FROM $BASE_DEV_IMAGE
 
+#Configurations for the test environment
+# ARG JUMP_SERVER_IP
+# ARG JUMP_SERVER_PORT
+# ARG JUMP_SERVER_USERNAME
+# ARG DUT_SERVER_IP
+# ARG TREX_SERVER_IP
+
+#Configurations for the general environment
 ARG UNAME=oai-spgwu
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Sao_Paulo
+ENV LANG=en_US.UTF-8
+
 WORKDIR /tmp/$UNAME
 
+#Install basic software to update repository list
 RUN apt-get update && \
-      apt-get -y install sudo git
+      apt-get install -y apt-transport-https ca-certificates curl gnupg-agent gnupg2 software-properties-common lsb-release && \
+      curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null && \
+      add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable"
 
-ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/Sao_Pauloa
+#Install deps packages
 RUN apt-get update && \
-      apt-get install -y tzdata
+      apt-get -y install sudo tzdata git cmake gcc g++ libconfig++ iproute2 iptables iputils-ping wget \
+      python3-pip locales ethtool docker-ce-cli libssl-dev rsync gdb bash-completion tmux \
+      tcpdump libelf-dev zlib1g clang llvm libasan5 linux-tools-common linux-headers-generic \
+      g++-multilib libc6-dev-i386 
 
-RUN apt-get update && \
-      apt-get -y install cmake
-
-RUN apt-get update && \
-      apt-get -y install gcc g++
-
-RUN apt-get update && \
-      apt-get -y install libconfig++
-
-RUN apt-get update && \
-      apt-get -y install iproute2
-
-RUN apt-get update && \
-      apt-get -y install iptables
-
-RUN apt-get update && \
-      apt-get -y install iputils-ping
-
-RUN apt-get update && \
-      apt-get -y install wget
-
-RUN apt-get update \
-      # Install Docker CE CLI
-      # The idea is to run docker network connect inside the container
-      && apt-get install -y apt-transport-https ca-certificates curl gnupg2 lsb-release \
-      && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
-      && echo "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list \
-      && apt-get update \
-      && apt-get install -y docker-ce-cli \
-      # Install Docker Compose
-      && LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")') \
+#Downloading Docker Compose
+RUN   LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")') \
       && curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
       && chmod +x /usr/local/bin/docker-compose
 
-RUN apt-get update && \
-      apt-get -y install tcpdump
-
-RUN apt-get update && \
-      apt-get -y install libelf-dev zlib1g clang llvm libasan5
-
-# TODO navarrothiago - CO-RE
-RUN apt-get update && \
-      apt-get -y install linux-tools-common linux-headers-generic
-
-RUN apt-get update && \
-      apt-get -y install g++-multilib libc6-dev-i386
-
-RUN apt-get update && \
-      apt-get -y install ethtool
-
-RUN apt-get update && \
-      apt-get -y install gdb
-
-RUN apt-get update && \
-    apt-get install  -y \
-    bash-completion
-
-RUN apt-get update && \
-    apt-get install  -y \
-    tmux
+#Installing python dependencies
+RUN pip3 install ipykernel matplotlib autopep8
 
 # Ubuntu 20.04 already support cmake 3.19.
-RUN if [ $BASE_DEV_IMAGE != "ubuntu:20.04" ];  then apt-get update && \
-      apt-get -y install libssl-dev && \
+RUN if [ $BASE_DEV_IMAGE != "ubuntu:20.04" ];  then \
       wget -c  https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.2.tar.gz -O - | tar -xz && \
       cd cmake-3.19.2 && ./bootstrap && make -j4 && make install; fi
 
 # Add your local bashrc
 ADD .bashrc /home/$USERNAME/
 ADD .bashrc /root/
-
-# Make ssh dir
-RUN mkdir /root/.ssh/
 
 # Copy over private key, and set permissions
 # WARNING! Anyone who gets their hands on this image will be able
@@ -99,54 +59,13 @@ ADD config /home/$USERNAME/.ssh/config
 # Create known_hosts
 # TODO navarrothiago - Put ssh-keyscan of the dut and trex server.
 RUN touch /root/.ssh/known_hosts
-RUN ssh-keyscan github.com >> /root/.ssh/known_hosts && \
-    ssh-keyscan gitlab.com >> /root/.ssh/known_hosts &&\
-    ssh-keyscan github.com >> /home/$USERNAME/.ssh/known_hosts &&\
-    ssh-keyscan gitlab.com >> /home/$USERNAME/.ssh/known_hosts && \
-    chown -R $USERNAME:$USERNAME /home/$USERNAME/.ssh 
-
-
-ARG JUMP_SERVER_IP
-ARG JUMP_SERVER_PORT
-ARG JUMP_SERVER_USERNAME
-ARG DUT_SERVER_IP
-ARG TREX_SERVER_IP
-
-RUN  if [[ -z "$JUMP_SERVER_IP" ]] ; then ssh-keyscan -p ${JUMP_SERVER_PORT} ${JUMP_SERVER_IP} >> /root/.ssh/known_hosts &&\
-    ssh ${JUMP_SERVER_USERNAME}@${JUMP_SERVER_IP} -p ${JUMP_SERVER_PORT} ssh-keyscan ${DUT_SERVER_IP} >> /root/.ssh/known_hosts &&\
-    ssh ${JUMP_SERVER_USERNAME}@${JUMP_SERVER_IP} -p ${JUMP_SERVER_PORT} ssh-keyscan ${TREX_SERVER_IP} >> /root/.ssh/known_hosts &&\
-    ssh-keyscan -p ${JUMP_SERVER_PORT} ${JUMP_SERVER_IP} >> /home/$USERNAME/.ssh/known_hosts &&\
-    ssh ${JUMP_SERVER_USERNAME}@${JUMP_SERVER_IP} -p ${JUMP_SERVER_PORT} ssh-keyscan ${DUT_SERVER_IP} >> /home/$USERNAME/.ssh/known_hosts &&\
-    ssh ${JUMP_SERVER_USERNAME}@${JUMP_SERVER_IP} -p ${JUMP_SERVER_PORT} ssh-keyscan ${TREX_SERVER_IP} >> /home/$USERNAME/.ssh/known_hosts; fi
 
 # Locales for Yocto
-ENV LANG=en_US.UTF-8
-RUN apt-get install -y locales && \
-    echo "$LANG UTF-8" > /etc/locale.gen && \
+RUN echo "$LANG UTF-8" > /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=$LAN
 
-# Install Docker CE CLI
-RUN apt-get update \
-    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
-    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y docker-ce-cli
-
 RUN chown root /root/.ssh/config
-
-RUN apt-get update && \
-    apt-get install  -y \
-    python3-pip
-
-RUN pip3 install ipykernel
-RUN pip3 install matplotlib
-RUN pip3 install autopep8
-
-RUN apt-get update && \
-    apt-get install  -y \
-    rsync
 
 # TODO: pass as ARG
 RUN echo "ENV_FILE=/workspaces/env.sh" >> /etc/environment
@@ -154,4 +73,7 @@ RUN echo "ENV_FILE=/workspaces/env.sh" >> /etc/environment
 # Omit if you want to keep the default as root.
 # USER $USERNAME
 
+COPY entrypoint.sh /entrypoint.sh
+
 CMD /bin/bash
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,5 +75,5 @@ RUN echo "ENV_FILE=/workspaces/env.sh" >> /etc/environment
 
 COPY entrypoint.sh /entrypoint.sh
 
-CMD /bin/bash
+CMD ["/bin/bash"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/build_docker
+++ b/docker/build_docker
@@ -21,21 +21,9 @@ main() {
 
   echo "Base image "${base_dev_image}""
 
-  #Copy env file to the context
-  cp "${env_file}" "${context}"/"${env_file_name}"
-
-  # Build dockerfile.
+  # build the image from dockerfile.
   docker build --tag="${IMAGE_TAG}":"${IMAGE_VERSION}" --rm -f "${context}"/"${DOCKERFILE}" "${context}" \
-               --build-arg ENV_FILENAME="${env_file_name}" \
-               --build-arg DUT_SERVER_IP="${DUT_IP}" \
-               --build-arg TREX_SERVER_IP="${TREX_SERVER_IP}" \
-               --build-arg JUMP_SERVER_USERNAME="${JUMP_SERVER_USERNAME}" \
-               --build-arg JUMP_SERVER_IP="${JUMP_SERVER_IP}" \
-               --build-arg JUMP_SERVER_PORT="${JUMP_SERVER_PORT}" \
                --build-arg BASE_DEV_IMAGE="${base_dev_image}"
-
-  # Remove env file from the context
-  rm "${context}"/"${env_file_name}"
 
   echo
   echo "Image "${IMAGE_TAG}" was build with base image "${base_dev_image}""

--- a/docker/build_docker
+++ b/docker/build_docker
@@ -21,14 +21,7 @@ main() {
 
   echo "Base image "${base_dev_image}""
 
-  # Copy configuration files and ssh keys to the docker context folder.
-  cp "${GIT_CONFIG}" "${context}"
-  cp "${SSH_FOLDER}"/"${SSH_PRIVATE_KEY_FILE}" "${context}"
-  cp "${SSH_FOLDER}"/"${SSH_PUBLIC_KEY_FILE}" "${context}"
-  cp "${SSH_FOLDER}"/"${SSH_CONFIG_FILE}" "${context}"
-  cp "${BASH_RC}" "${context}"
-  # echo ""${WORKSPACE}"/env.sh" > "${BASH_RC}"
-
+  #Copy env file to the context
   cp "${env_file}" "${context}"/"${env_file_name}"
 
   # Build dockerfile.
@@ -41,12 +34,7 @@ main() {
                --build-arg JUMP_SERVER_PORT="${JUMP_SERVER_PORT}" \
                --build-arg BASE_DEV_IMAGE="${base_dev_image}"
 
-  # Remove configuration files and ssh keys from the docker context folder.
-  rm "${context}"/.gitconfig
-  rm "${context}"/"${SSH_PRIVATE_KEY_FILE}"
-  rm "${context}"/"${SSH_PUBLIC_KEY_FILE}"
-  rm "${context}"/"${SSH_CONFIG_FILE}"
-  rm "${context}"/.bashrc
+  # Remove env file from the context
   rm "${context}"/"${env_file_name}"
 
   echo

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.6"
+
+services:
+  upf-bpf:
+    image: ${IMAGE}
+    env_file: ${ENV_FILE}
+    secrets:
+      - SSH_PRIV_KEY
+      - SSH_PUBL_KEY
+      - SSH_CONF_FILE
+      - BASH_RC_FILE
+      - GIT_CONFIG_FILE
+    privileged: true
+    working_dir: ${WORKSPACE}
+    #stdin_open: true
+    #tty: true
+    volumes:
+      - ${VOLUME}
+
+secrets:
+  SSH_PRIV_KEY:
+    file: ${SSH_PRIV_KEY}
+  SSH_PUBL_KEY:
+    file: ${SSH_PUBL_KEY}
+  SSH_CONF_FILE:
+    file: ${SSH_CONF_FILE}
+  BASH_RC_FILE:
+    file: ${BASH_RC_FILE}
+  GIT_CONFIG_FILE:
+    file: ${GIT_CONFIG_FILE}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,13 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Creating directory for root user SSH configuration
-mkdir -p /root/.ssh/
+SSH_ROOT_DIR=/root/.ssh/
+mkdir -p "${SSH_ROOT_DIR}"
 
 #Defining keys to known hosts explicitly
 ssh-keyscan github.com >> /root/.ssh/known_hosts
 ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
 
-#If the variables for the test environment are defined, then we'll define the keys for the DUT and TREX servers too
+#If the variables for the SSH jump server are defined, then we'll get the host keys from the DUT
+# and TRex servers to it.
 if  [ -n "$JUMP_SERVER_IP" ] && [ -n "$JUMP_SERVER_USERNAME" ] && [ -n "$JUMP_SERVER_PORT" ] && \
     [ -n "$DUT_SERVER_IP" ] && [ -n "$TREX_SERVER_IP" ]; then
     ssh-keyscan -p ${JUMP_SERVER_PORT} ${JUMP_SERVER_IP} >> /root/.ssh/known_hosts
@@ -17,12 +19,50 @@ if  [ -n "$JUMP_SERVER_IP" ] && [ -n "$JUMP_SERVER_USERNAME" ] && [ -n "$JUMP_SE
     $JUMP_SERVER_SSH_CMD ssh-keyscan ${TREX_SERVER_IP} >> /root/.ssh/known_hosts
 fi
 
-#If the username is no the root user, then we'll copy the configuration for the user too
-if [ $USERNAME != "root" ]; then
+#If the secrets are defined, them they will be copied to the root user ssh folder
+# so we can set the correct permissions and ownership
+SECRETS_FOLDER="/var/run/secrets"
+if [ -f ${SECRETS_FOLDER}/SSH_PRIV_KEY ]; then cp ${SECRETS_FOLDER}/SSH_PRIV_KEY \
+   "${SSH_ROOT_DIR}"/${SSH_PRIVATE_KEY_FILE}; fi
+if [ -f ${SECRETS_FOLDER}/SSH_PUBL_KEY ]; then cp ${SECRETS_FOLDER}/SSH_PUBL_KEY \
+    "${SSH_ROOT_DIR}"/${SSH_PUBLIC_KEY_FILE}; fi
+if [ -f ${SECRETS_FOLDER}/SSH_CONF_FILE ]; then cp ${SECRETS_FOLDER}/SSH_CONF_FILE \
+    "${SSH_ROOT_DIR}"/${SSH_CONFIG_FILE}; fi
+if [ -f ${SECRETS_FOLDER}/BASH_RC_FILE ]; then cp ${SECRETS_FOLDER}/BASH_RC_FILE \
+    /root ; fi
+if [ -f ${SECRETS_FOLDER}/GIT_CONFIG_FILE ]; then cp ${SECRETS_FOLDER}/GIT_CONFIG_FILE \
+    /root ; fi
+chown -R root:root "${SSH_ROOT_DIR}"
+chmod -R 600 "${SSH_ROOT_DIR}"
+
+#If the username is not the root user, then we'll copy the configuration
+# for the user too
+if [ -n "$USERNAME" ] && [ $USERNAME != "root" ]; then
+    USERHOME="/home/$USERNAME"
+
+    #UNIX
+    useradd $USERNAME --uid 1000 --shell /bin/bash -G sudo \
+    --create-home --home ${USERHOME}/ --user-group
+    passwd -d $USERNAME
+
     #SSH
-    mkdir -p /home/$USERNAME/.ssh
-    cp /root/.ssh/known_hosts /home/$USERNAME/.ssh/known_hosts
-    chown -R $USERNAME:$USERNAME /home/$USERNAME/.ssh
+    mkdir -p ${USERHOME}/.ssh
+    cp ${SSH_FOLDER}/* ${USERHOME}/.ssh/
+
+    #BASHRC
+    if [ -f ${SECRETS_FOLDER}/BASH_RC_FILE ]; then cp ${BASH_RC} \
+        ${USERHOME}/$(basename ${BASH_RC}); fi
+
+    #GITCONFIG
+    if [ -f ${SECRETS_FOLDER}/GIT_CONFIG_FILE ]; then cp ${GIT_CONFIG} \
+        ${USERHOME}/$(basename ${GIT_CONFIG}); fi
+
+    chown -R $USERNAME:$USERNAME ${USERHOME}
 fi
 
-exec $@
+#Entering the execution command as the user or as the root user
+if [ -n "$USERNAME" ] && [ $USERNAME != "root" ]; then
+    gosu $USERNAME "$@"
+else
+    exec "$@"
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,64 +1,89 @@
 #!/usr/bin/env bash
 
-#Creating directory for root user SSH configuration
-SSH_ROOT_DIR=/root/.ssh/
-mkdir -p "${SSH_ROOT_DIR}"
-
-#Defining keys to known hosts explicitly
-ssh-keyscan github.com >> /root/.ssh/known_hosts
-ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
-
-#If the variables for the SSH jump server are defined, then we'll get the host keys from the DUT
-# and TRex servers to it.
-if  [ -n "$JUMP_SERVER_IP" ] && [ -n "$JUMP_SERVER_USERNAME" ] && [ -n "$JUMP_SERVER_PORT" ] && \
-    [ -n "$DUT_SERVER_IP" ] && [ -n "$TREX_SERVER_IP" ]; then
-    ssh-keyscan -p ${JUMP_SERVER_PORT} ${JUMP_SERVER_IP} >> /root/.ssh/known_hosts
-
-    JUMP_SERVER_SSH_CMD="ssh ${JUMP_SERVER_USERNAME}@${JUMP_SERVER_IP} -p ${JUMP_SERVER_PORT}"
-    $JUMP_SERVER_SSH_CMD ssh-keyscan ${DUT_SERVER_IP} >> /root/.ssh/known_hosts
-    $JUMP_SERVER_SSH_CMD ssh-keyscan ${TREX_SERVER_IP} >> /root/.ssh/known_hosts
-fi
-
-#If the secrets are defined, them they will be copied to the root user ssh folder
-# so we can set the correct permissions and ownership
+#Global Variables
 SECRETS_FOLDER="/var/run/secrets"
-if [ -f ${SECRETS_FOLDER}/SSH_PRIV_KEY ]; then cp ${SECRETS_FOLDER}/SSH_PRIV_KEY \
-   "${SSH_ROOT_DIR}"/${SSH_PRIVATE_KEY_FILE}; fi
-if [ -f ${SECRETS_FOLDER}/SSH_PUBL_KEY ]; then cp ${SECRETS_FOLDER}/SSH_PUBL_KEY \
-    "${SSH_ROOT_DIR}"/${SSH_PUBLIC_KEY_FILE}; fi
-if [ -f ${SECRETS_FOLDER}/SSH_CONF_FILE ]; then cp ${SECRETS_FOLDER}/SSH_CONF_FILE \
-    "${SSH_ROOT_DIR}"/${SSH_CONFIG_FILE}; fi
-if [ -f ${SECRETS_FOLDER}/BASH_RC_FILE ]; then cp ${SECRETS_FOLDER}/BASH_RC_FILE \
-    /root ; fi
-if [ -f ${SECRETS_FOLDER}/GIT_CONFIG_FILE ]; then cp ${SECRETS_FOLDER}/GIT_CONFIG_FILE \
-    /root ; fi
-chown -R root:root "${SSH_ROOT_DIR}"
-chmod -R 600 "${SSH_ROOT_DIR}"
 
-#If the username is not the root user, then we'll copy the configuration
-# for the user too
-if [ -n "$USERNAME" ] && [ $USERNAME != "root" ]; then
-    USERHOME="/home/$USERNAME"
-
-    #UNIX
+#Function to create the user defined in the USERNAME Env
+CreateUser() {
     useradd $USERNAME --uid 1000 --shell /bin/bash -G sudo \
     --create-home --home ${USERHOME}/ --user-group
     passwd -d $USERNAME
+}
 
-    #SSH
-    mkdir -p ${USERHOME}/.ssh
-    cp ${SSH_FOLDER}/* ${USERHOME}/.ssh/
+#Function to copy Secrets files to user home directory
+ConfigureSSH() {
+    if [ ! -d "${SSH_HOME_DIR}" ]; then
+        mkdir -p "${SSH_HOME_DIR}"
+    fi
 
-    #BASHRC
-    if [ -f ${SECRETS_FOLDER}/BASH_RC_FILE ]; then cp ${BASH_RC} \
-        ${USERHOME}/$(basename ${BASH_RC}); fi
+    #Defining keys to known hosts explicitly
+    ssh-keyscan github.com >> ${SSH_HOME_DIR}/known_hosts
+    ssh-keyscan gitlab.com >> ${SSH_HOME_DIR}/known_hosts
 
-    #GITCONFIG
-    if [ -f ${SECRETS_FOLDER}/GIT_CONFIG_FILE ]; then cp ${GIT_CONFIG} \
-        ${USERHOME}/$(basename ${GIT_CONFIG}); fi
+    #If the variables for the SSH jump server are defined, then we'll get the host keys from the DUT
+    # and TRex servers to it.
+    if  [ -n "$JUMP_SERVER_IP" ] && [ -n "$JUMP_SERVER_USERNAME" ] && [ -n "$JUMP_SERVER_PORT" ] && \
+        [ -n "$DUT_SERVER_IP" ] && [ -n "$TREX_SERVER_IP" ]; then
+        ssh-keyscan -p ${JUMP_SERVER_PORT} ${JUMP_SERVER_IP} >> ${SSH_HOME_DIR}/known_hosts
 
-    chown -R $USERNAME:$USERNAME ${USERHOME}
+        JUMP_SERVER_SSH_CMD="ssh ${JUMP_SERVER_USERNAME}@${JUMP_SERVER_IP} -p ${JUMP_SERVER_PORT}"
+        $JUMP_SERVER_SSH_CMD ssh-keyscan ${DUT_SERVER_IP} >> ${SSH_HOME_DIR}/known_hosts
+        $JUMP_SERVER_SSH_CMD ssh-keyscan ${TREX_SERVER_IP} >> ${SSH_HOME_DIR}/known_hosts
+    fi
+
+    #If the secrets are defined, them they will be copied to the root user ssh folder
+    # so we can set the correct permissions and ownership
+    if [ -f ${SECRETS_FOLDER}/SSH_PRIV_KEY ]; then 
+        cp ${SECRETS_FOLDER}/SSH_PRIV_KEY "${SSH_HOME_DIR}"/${SSH_PRIVATE_KEY_FILE} && \
+        export SSH_PRIVATE_KEY_FILE="${SSH_HOME_DIR}/${SSH_PRIVATE_KEY_FILE}"
+    fi
+    if [ -f ${SECRETS_FOLDER}/SSH_PUBL_KEY ]; then
+        cp ${SECRETS_FOLDER}/SSH_PUBL_KEY "${SSH_HOME_DIR}"/${SSH_PUBLIC_KEY_FILE} && \
+        export SSH_PUBLIC_KEY_FILE="${SSH_HOME_DIR}/${SSH_PUBLIC_KEY_FILE}"
+    fi
+    if [ -f ${SECRETS_FOLDER}/SSH_CONF_FILE ]; then
+        cp ${SECRETS_FOLDER}/SSH_CONF_FILE "${SSH_HOME_DIR}/${SSH_CONFIG_FILE}" && \
+        export SSH_CONFIG_FILE="${SSH_HOME_DIR}/${SSH_CONFIG_FILE}"
+    fi
+
+    #Correcting permissions
+    chown -R ${USERNAME}:${USERNAME} "${USERHOME}"
+    chmod -R 770 ${USERHOME}
+    chmod -R 600 ${SSH_HOME_DIR}/*
+}
+
+#Function to configure the .gitconfig file for the user
+ConfigureGit() {
+    if [ -f ${SECRETS_FOLDER}/GIT_CONFIG_FILE ]; then
+        cp ${SECRETS_FOLDER}/GIT_CONFIG_FILE ${USERHOME}/$(basename ${GIT_CONFIG}) && \
+        export GIT_CONFIG="${USERHOME}/$(basename ${GIT_CONFIG})"
+    fi
+}
+
+#Function to configure the .bashrc file for the user
+ConfigureBashRC() {
+    if [ -f ${SECRETS_FOLDER}/BASH_RC_FILE ]; then
+        cp ${SECRETS_FOLDER}/BASH_RC_FILE ${USERHOME}/$(basename ${BASH_RC}) && \
+        export BASH_RC="${USERHOME}/$(basename ${BASH_RC})"
+    fi
+}
+
+#Defining user context configuration
+if [ -n "$USERNAME" ] && [ $USERNAME != "root" ]; then
+    USERHOME="/home/$USERNAME"
+    SSH_HOME_DIR="${USERHOME}/.ssh"
+
+    #Create the User inside the container
+    CreateUser
+else
+    USERHOME="/root"
+    SSH_HOME_DIR="${USERHOME}/.ssh"
 fi
+
+#Making Configurations
+ConfigureSSH
+ConfigureGit
+ConfigureBashRC
 
 #Entering the execution command as the user or as the root user
 if [ -n "$USERNAME" ] && [ $USERNAME != "root" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#Creating directory for root user SSH configuration
+mkdir -p /root/.ssh/
+
+#Defining keys to known hosts explicitly
+ssh-keyscan github.com >> /root/.ssh/known_hosts
+ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
+
+#If the variables for the test environment are defined, then we'll define the keys for the DUT and TREX servers too
+if  [ -n "$JUMP_SERVER_IP" ] && [ -n "$JUMP_SERVER_USERNAME" ] && [ -n "$JUMP_SERVER_PORT" ] && \
+    [ -n "$DUT_SERVER_IP" ] && [ -n "$TREX_SERVER_IP" ]; then
+    ssh-keyscan -p ${JUMP_SERVER_PORT} ${JUMP_SERVER_IP} >> /root/.ssh/known_hosts
+
+    JUMP_SERVER_SSH_CMD="ssh ${JUMP_SERVER_USERNAME}@${JUMP_SERVER_IP} -p ${JUMP_SERVER_PORT}"
+    $JUMP_SERVER_SSH_CMD ssh-keyscan ${DUT_SERVER_IP} >> /root/.ssh/known_hosts
+    $JUMP_SERVER_SSH_CMD ssh-keyscan ${TREX_SERVER_IP} >> /root/.ssh/known_hosts
+fi
+
+#If the username is no the root user, then we'll copy the configuration for the user too
+if [ $USERNAME != "root" ]; then
+    #SSH
+    mkdir -p /home/$USERNAME/.ssh
+    cp /root/.ssh/known_hosts /home/$USERNAME/.ssh/known_hosts
+    chown -R $USERNAME:$USERNAME /home/$USERNAME/.ssh
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,3 +24,5 @@ if [ $USERNAME != "root" ]; then
     cp /root/.ssh/known_hosts /home/$USERNAME/.ssh/known_hosts
     chown -R $USERNAME:$USERNAME /home/$USERNAME/.ssh
 fi
+
+exec $@

--- a/docker/run_docker
+++ b/docker/run_docker
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+generate_env_file() {
+  echo -n "" > ${ENV_FILE}
+  while read line; do
+    var="$(echo "${line}" | cut -d "=" -f1)"
+    value="$(echo "${line}" | cut -d "=" -f2-)"
+    echo "${var}=$(eval echo ${!var} )" >> ${ENV_FILE}
+  done < <(cat ${BASEDIRNAME}/env.sh | sed '/^#/d;/^$/d')
+}
+
 main() {
 
   set -o errexit
@@ -8,12 +17,26 @@ main() {
   local -r dirname="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   source "${dirname}"/../env.sh
 
-	docker run -it --rm \
-		--env-file "${dirname}"/../env.sh \
-		--volume "${dirname}"/../:"${WORKSPACE}" \
-		--privileged \
-		--workdir "${WORKSPACE}" "${IMAGE_TAG}":"${IMAGE_VERSION}" \
-		/bin/bash
+  #Exporting variables to be used on compose file
+  export BASEDIRNAME="$(cd "${dirname}/../" && pwd)"
+  export IMAGE="${IMAGE_TAG}:${IMAGE_VERSION}"
+  export ENV_FILE="${BASEDIRNAME}/docker/env.temp"
+  export WORKSPACE="${WORKSPACE}"
+  export VOLUME="${BASEDIRNAME}:${WORKSPACE}"
+  export SSH_PRIV_KEY="${SSH_FOLDER}/${SSH_PRIVATE_KEY_FILE}"
+  export SSH_PUBL_KEY="${SSH_FOLDER}/${SSH_PUBLIC_KEY_FILE}"
+  export SSH_CONF_FILE="${SSH_FOLDER}/${SSH_CONFIG_FILE}"
+  export BASH_RC_FILE="${BASH_RC}"
+  export GIT_CONFIG_FILE="${GIT_CONFIG}"
+
+  #Generating temporary env file for the service context in compose
+  generate_env_file
+
+  #Running the Container from service upf-bpf
+  docker-compose -f "${dirname}"/"${DOCKERCOMPOSEFILE}" run upf-bpf
+
+  #Removing temporary generated env file
+  rm -f "${BASEDIRNAME}/docker/env.temp"
 
   exit 0
 }


### PR DESCRIPTION
This PR will change the working environment for dev and test that is currenctly based on a on-build configuration inside the Dockerfile to a Docker-Compose based environment that can be configured on runtime using the variables from the environment file. It'll add a Entrypoint script to make the environment be configured on run, making it easier to make adjustments on the environment without rebuilding the whole docker image.