### PR TITLE
cleaning temp file even on exit error status

### DIFF
--- a/docker/run_docker
+++ b/docker/run_docker
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+CleanUp() {
+  if [ -e "${ENV_FILE}" ]; then rm -f "${ENV_FILE}"; fi
+}
+
 generate_env_file() {
   echo -n "" > ${ENV_FILE}
   while read line; do
@@ -9,7 +14,6 @@ generate_env_file() {
 }
 
 main() {
-
   set -o errexit
   set -o pipefail
   set -o nounset
@@ -36,7 +40,8 @@ main() {
   docker-compose -f "${dirname}"/"${DOCKERCOMPOSEFILE}" run upf-bpf
 
   #Removing temporary generated env file
-  rm -f "${BASEDIRNAME}/docker/env.temp"
+  trap CleanUp EXIT
+  trap exit EXIT
 
   exit 0
 }


### PR DESCRIPTION
The run_docker script wasn't cleaning the temp file when the user exited the dev container with a exit command due to "set -o errexit" option in the script. Updated with a trap function to clean the environment even on a exit code > 0.